### PR TITLE
Run pdflatex three times when creating architecture PDF

### DIFF
--- a/findbugs/design/architecture/Makefile
+++ b/findbugs/design/architecture/Makefile
@@ -4,6 +4,7 @@ PDFS = $(TEX_SRCS:.tex=.pdf)
 %.pdf : %.tex
 	pdflatex $*
 	pdflatex $*
+	pdflatex $*
 
 all : $(PDFS)
 


### PR DESCRIPTION
On Fedora (at least), the second run of pdflatex prints a warning:

    LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right.

The third run doesn't print any warnings.