### PR TITLE
Tell guideline when reporter opens new-issue page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+Please use SourceForge trackers for bug reports and feature enhancements:
+
+http://sourceforge.net/p/findbugs/bugs/
+
+Thank you for the feedback!
+
+Regards,
+Andrei


### PR DESCRIPTION
GitHub provides [a feature to tell guideline when reporter opens new-issue page and new-pr page](https://github.com/blog/1184-contributing-guidelines).
This feature will help us to follow guideline even when reporter does not know it.
