### PR TITLE
add .travis.yml to build on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+sudo: false
+jdk:
+  - oraclejdk7
+install:
+  - wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O eclipse-3.6.2-linux64.tar.gz
+  - tar xzvf eclipse-3.6.2-linux64.tar.gz eclipse
+  - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
+script: ant build test
+notifications:
+  email:
+    recipients:
+      - skypencil+travis@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,18 @@ language: java
 sudo: false
 jdk:
   - oraclejdk7
+env:
+  matrix:
+    - JDK_FOR_TEST=oraclejdk7
+    - JDK_FOR_TEST=oraclejdk8
 install:
   - wget http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops/R-3.6.2-201102101200/eclipse-SDK-3.6.2-linux-gtk-x86_64.tar.gz -O eclipse-3.6.2-linux64.tar.gz
   - tar xzvf eclipse-3.6.2-linux64.tar.gz eclipse
   - echo eclipsePlugin.dir=$(pwd)/eclipse/plugins > eclipsePlugin/local.properties
-script: ant build test
+script:
+  - ant build
+  - jdk_switcher use $JDK_FOR_TEST
+  - ant test
 notifications:
   email:
     recipients:


### PR DESCRIPTION
This PR is a suggestion to introduce [TravisCI](https://travis-ci.org/) to this project. Here is an example:
- https://travis-ci.org/KengoTODA/findbugs-1/builds/81225448

To build on Travis CI, organization owner needs to sign-in to Travis CI and configure to enable Travis CI for findbugsproject organization.
