### PR TITLE
[javadoc] explain sample values and related classes to improve readability

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/internalAnnotations/DottedClassName.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/internalAnnotations/DottedClassName.java
@@ -30,7 +30,11 @@ import javax.annotation.meta.When;
  * Denotes a class name or package name where the . character is used to
  * separate package/class name components.
  *
+ * e.g. {@code java.util.Collection}, {@code foo.Bar$Baz}
+ *
  * @author pugh
+ * @see edu.umd.cs.findbugs.util.ClassName An utility class provides utility methods to handle this format
+ * @see SlashedClassName Another format of class name
  */
 @Documented
 @SlashedClassName(when = When.NEVER)

--- a/findbugs/src/java/edu/umd/cs/findbugs/internalAnnotations/SlashedClassName.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/internalAnnotations/SlashedClassName.java
@@ -30,10 +30,14 @@ import javax.annotation.meta.TypeQualifierValidator;
 import javax.annotation.meta.When;
 
 /**
- * * Denotes a class name or package name where the / character is used to
+ * Denotes a class name or package name where the / character is used to
  * separate package/class name components.
  *
+ * e.g. {@code java/util/Collection}, {@code foo/Bar$Baz}
+ *
  * @author pugh
+ * @see edu.umd.cs.findbugs.util.ClassName An utility class provides utility methods to handle this format
+ * @see DottedClassName Another format of class name
  */
 @Documented
 @TypeQualifier(applicableTo = CharSequence.class)


### PR DESCRIPTION
This is a suggestion to help newbies to catch-up FindBugs, by javadoc improvement.

It's good to tell the existence of an utility class `edu.umd.cs.findbugs.util.ClassName`, for users of `@ SlashedClassName` and `@DottedClassName`.
It's also good to add sample values into javadoc, because it's easier than regexp to understand its format.