### PR TITLE
Ant task support for specifying multiple filters

### DIFF
--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -51,9 +51,11 @@ import edu.umd.cs.findbugs.ExitCodes;
  * <li>debug (boolean default false)
  * <li>effort (enum min|default|max)</li>
  * <li>excludeFilter (filter filename)
+ * <li>excludePath (classpath or classpathRef to filters)
  * <li>failOnError (boolean - default false)
  * <li>home (findbugs install dir)
  * <li>includeFilter (filter filename)
+ * <li>includePath (classpath or classpathRef to filters)
  * <li>maxRank (maximum rank issue to be reported)
  * <li>jvm (Set the command used to start the VM)
  * <li>jvmargs (any additional jvm arguments)
@@ -136,7 +138,11 @@ public class FindBugsTask extends AbstractFindBugsTask {
 
     private File excludeFile;
 
+    private Path excludePath;
+
     private File includeFile;
+
+    private Path includePath;
 
     private Path auxClasspath;
 
@@ -535,6 +541,62 @@ public class FindBugsTask extends AbstractFindBugsTask {
     }
 
     /**
+     * the sourcepath to use.
+     */
+    public void setExcludePath(Path src) {
+        if (excludePath == null) {
+            excludePath = src;
+        } else {
+            excludePath.append(src);
+        }
+    }
+
+    /**
+     * Path to use for sourcepath.
+     */
+    public Path createExcludePath() {
+        if (excludePath == null) {
+            excludePath = new Path(getProject());
+        }
+        return excludePath.createPath();
+    }
+
+    /**
+     * Adds a reference to a source path defined elsewhere.
+     */
+    public void setExcludePathRef(Reference r) {
+        createExcludePath().setRefid(r);
+    }
+
+    /**
+     * the sourcepath to use.
+     */
+    public void setIncludePath(Path src) {
+        if (includePath == null) {
+            includePath = src;
+        } else {
+            includePath.append(src);
+        }
+    }
+
+    /**
+     * Path to use for sourcepath.
+     */
+    public Path createIncludePath() {
+        if (includePath == null) {
+            includePath = new Path(getProject());
+        }
+        return includePath.createPath();
+    }
+
+    /**
+     * Adds a reference to a source path defined elsewhere.
+     */
+    public void setIncludePathRef(Reference r) {
+        createIncludePath().setRefid(r);
+    }
+
+    /**
      * Add a class location
      */
     public ClassLocation createClass() {
@@ -728,9 +790,23 @@ public class FindBugsTask extends AbstractFindBugsTask {
             addArg("-exclude");
             addArg(excludeFile.getPath());
         }
+        if (excludePath != null) {
+            String[] result = excludePath.toString().split(java.io.File.pathSeparator);
+            for (int x = 0; x < result.length; x++) {
+                addArg("-exclude");
+                addArg(result[x]);
+            }
+        }
         if (includeFile != null) {
             addArg("-include");
             addArg(includeFile.getPath());
+        }
+        if (includePath != null) {
+            String[] result = includePath.toString().split(java.io.File.pathSeparator);
+            for (int x = 0; x < result.length; x++) {
+                addArg("-include");
+                addArg(result[x]);
+            }
         }
         if (visitors != null) {
             addArg("-visitors");

--- a/findbugs/src/doc/manual.xml
+++ b/findbugs/src/doc/manual.xml
@@ -1474,12 +1474,70 @@ using the &FindBugs; task.
   </varlistentry>
 
   <varlistentry>
+    <term><literal>excludePath</literal></term>
+    <listitem>
+       <para>
+       Since Findbugs 3.0.2.
+       </para>
+       <para>
+       An optional nested element which specifies a path
+       containing filters specifying bugs
+       to exclude from being reported.  See <xref linkend="filter" />.
+       </para>
+       <para>
+		Example:
+
+		<screen>
+		    &lt;findbugs home="${findbugs.home}">
+		      &lt;excludePath&gt;
+		              &lt;path&gt;
+		                      &lt;fileset dir="${findbugs-exclusion-filters.dir}" includes="findbugs-*-exclude-filter.xml" /&gt;
+		              &lt;/path&gt;
+		      &lt;/excludePath&gt;
+		    &lt;/findbugs&gt;
+		</screen>
+
+		See <ulink url="https://ant.apache.org/manual/using.html#path">Apache Ant's Path-like Structures documentation</ulink> for details.
+		</para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
     <term><literal>includeFilter</literal></term>
     <listitem>
        <para>
        Optional attribute.  It specifies the filename of a filter specifying
        which bugs are reported.  See <xref linkend="filter" />.
        </para>
+    </listitem>
+  </varlistentry>
+
+  <varlistentry>
+    <term><literal>includePath</literal></term>
+    <listitem>
+       <para>
+       Since Findbugs 3.0.2.
+       </para>
+       <para>
+       An optional nested element which specifies a path
+       containing filters specifying which bugs
+       are reported.  See <xref linkend="filter" />.
+       </para>
+       <para>
+		Example:
+
+		<screen>
+		    &lt;findbugs home="${findbugs.home}">
+		      &lt;includePath&gt;
+		              &lt;path&gt;
+		                      &lt;fileset dir="${findbugs-inclusion-filters.dir}" includes="findbugs-*-include-filter.xml" /&gt;
+		              &lt;/path&gt;
+		      &lt;/includePath&gt;
+		    &lt;/findbugs&gt;
+		</screen>
+
+		See <ulink url="https://ant.apache.org/manual/using.html#path">Apache Ant's Path-like Structures documentation</ulink> for details.
+		</para>
     </listitem>
   </varlistentry>
 


### PR DESCRIPTION
Here's a patch for adding optional excludePath and includePath nested elements to the findbugs ant task along with updates to the manual.