### PR TITLE
Ant task parses stdin as argv

### DIFF
--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/AbstractFindBugsTask.java
@@ -95,6 +95,8 @@ public abstract class AbstractFindBugsTask extends Task {
 
     public String execResultProperty = "edu.umd.cs.findbugs.anttask.AbstractFindBugsTask" + "." + RESULT_PROPERTY_SUFFIX;
 
+    private StringBuffer inputStringBuffer = null;
+
     /**
      * Constructor.
      */
@@ -353,8 +355,21 @@ public abstract class AbstractFindBugsTask extends Task {
      * Sets the given string to be piped to standard input of the FindBugs JVM
      * upon launching.
      */
+    protected void appendToInputString(String input) {
+        if (null == inputStringBuffer) {
+            inputStringBuffer = new StringBuffer();
+        }
+        inputStringBuffer.append(input);
+    }
+    protected void appendToInputString(char input) {
+        if (null == inputStringBuffer) {
+            inputStringBuffer = new StringBuffer();
+        }
+        inputStringBuffer.append(input);
+    }
     protected void setInputString(String input) {
-        findbugsEngine.setInputString(input);
+        inputStringBuffer = new StringBuffer();
+        inputStringBuffer.append(input);
     }
 
     /**
@@ -369,6 +384,10 @@ public abstract class AbstractFindBugsTask extends Task {
         configureFindbugsEngine();
 
         beforeExecuteJavaProcess();
+
+        if (null != inputStringBuffer) {
+            findbugsEngine.setInputString(inputStringBuffer.toString());
+        }
 
         if (getDebug()) {
             log(getFindbugsEngine().getCommandLine().describeCommand());

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -791,10 +791,24 @@ public class FindBugsTask extends AbstractFindBugsTask {
             addArg(excludeFile.getPath());
         }
         if (excludePath != null) {
-            String[] result = excludePath.toString().split(java.io.File.pathSeparator);
-            for (int x = 0; x < result.length; x++) {
-                addArg("-exclude");
-                addArg(result[x]);
+            String excludePathValue = excludePath.toString();
+            if (!excludePathValue.isEmpty()) {
+                if (excludePathValue.length() > 100) {
+                    addArg("-parseStdinAsOptions");
+                    String[] result = excludePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        appendToInputString("-exclude");
+                        appendToInputString('\n');
+                        appendToInputString(result[x]);
+                        appendToInputString('\n');
+                    }
+                } else {
+                    String[] result = excludePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        addArg("-exclude");
+                        addArg(result[x]);
+                    }
+                }
             }
         }
         if (includeFile != null) {
@@ -802,10 +816,24 @@ public class FindBugsTask extends AbstractFindBugsTask {
             addArg(includeFile.getPath());
         }
         if (includePath != null) {
-            String[] result = includePath.toString().split(java.io.File.pathSeparator);
-            for (int x = 0; x < result.length; x++) {
-                addArg("-include");
-                addArg(result[x]);
+            String includePathValue = includePath.toString();
+            if (!includePathValue.isEmpty()) {
+                if (includePathValue.length() > 100) {
+                    addArg("-parseStdinAsOptions");
+                    String[] result = includePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        appendToInputString("-include");
+                        appendToInputString('\n');
+                        appendToInputString(result[x]);
+                        appendToInputString('\n');
+                    }
+                } else {
+                    String[] result = includePathValue.split(java.io.File.pathSeparator);
+                    for (int x = 0; x < result.length; x++) {
+                        addArg("-include");
+                        addArg(result[x]);
+                    }
+                }
             }
         }
         if (visitors != null) {

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -756,8 +756,12 @@ public class FindBugsTask extends AbstractFindBugsTask {
                 String auxClasspathString = auxClasspath.toString();
                 if (!auxClasspathString.isEmpty()) {
                     if (auxClasspathString.length() > 100) {
-                        addArg("-auxclasspathFromInput");
-                        setInputString(auxClasspathString);
+                        addArg("-parseStdinAsOptions");
+
+                        appendToInputString("-auxclasspath");
+                        appendToInputString('\n');
+                        appendToInputString(auxClasspathString);
+                        appendToInputString('\n');
                     } else {
                         addArg("-auxclasspath");
                         addArg(auxClasspathString);
@@ -768,8 +772,20 @@ public class FindBugsTask extends AbstractFindBugsTask {
             }
         }
         if (sourcePath != null) {
-            addArg("-sourcepath");
-            addArg(sourcePath.toString());
+            String sourcePathValue = sourcePath.toString();
+            if (!sourcePathValue.isEmpty()) {
+                if (sourcePathValue.length() > 100) {
+                    addArg("-parseStdinAsOptions");
+
+                    appendToInputString("-sourcepath");
+                    appendToInputString('\n');
+                    appendToInputString(sourcePathValue);
+                    appendToInputString('\n');
+                } else {
+                    addArg("-sourcepath");
+                    addArg(sourcePathValue);
+                }
+            }
         }
         if (outputFileName != null) {
             addArg("-outputFile");

--- a/findbugs/src/doc/manual.xml
+++ b/findbugs/src/doc/manual.xml
@@ -928,6 +928,18 @@ These options are only accepted by the Text User Interface.
   </varlistentry>
 
   <varlistentry>
+  <term><command>-parseStdinAsOptions</command> </term>
+  <listitem>
+    <para>
+    Read additional options from from standard input, with each new line as a separate argument.
+    This option is incompatible with other arguments using standard input,
+    such as -auxclasspathFromInput and reading files or data from standard input.
+    -auxclasspathFromInput can be replaced with -auxclasspath followed by a classpath line.
+    </para>
+  </listitem>
+  </varlistentry>
+
+  <varlistentry>
   <term><command>-auxclasspath</command> <replaceable>classpath</replaceable></term>
   <listitem>
     <para>

--- a/findbugs/src/java/edu/umd/cs/findbugs/TextUICommandLine.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/TextUICommandLine.java
@@ -203,6 +203,7 @@ public class TextUICommandLine extends FindBugsCommandLine {
         addOption("-adjustPriority", "v1=(raise|lower)[,...]", "raise/lower priority of warnings for given visitor(s)");
 
         startOptionGroup("Project configuration options:");
+        addSwitch("-parseStdinAsOptions", "read additional options from standard input, one argument per line");
         addOption("-auxclasspath", "classpath", "set aux classpath for analysis");
         addSwitch("-auxclasspathFromInput", "read aux classpath from standard input");
         addOption("-auxclasspathFromFile", "filepath", "read aux classpaths from a designated file");

--- a/findbugs/src/java/edu/umd/cs/findbugs/config/CommandLine.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/config/CommandLine.java
@@ -308,12 +308,24 @@ public abstract class CommandLine {
     }
 
     private int parse(String argv[], boolean dryRun) throws IOException, HelpRequestedException {
+        // Needed to prevent infinite recursion in the case of -parseStdinAsOptions showing up in stdin
+        boolean parsingStdin = false;
+        return parse(argv, parsingStdin, dryRun);
+    }
+
+    private int parse(String argv[], boolean parsingStdin, boolean dryRun) throws IOException, HelpRequestedException {
         int arg = 0;
+        boolean parseStdinAsOptions = false;
 
         while (arg < argv.length) {
             String option = argv[arg];
             if ("-help".equals(option) || "-h".equals(option)) {
                 throw new HelpRequestedException();
+            }
+            if ("-parseStdinAsOptions".equals(option)) {
+                parseStdinAsOptions = true;
+                ++arg;
+                continue;
             }
             if (!option.startsWith("-")) {
                 break;
@@ -351,7 +363,31 @@ public abstract class CommandLine {
             }
         }
 
+        if (!dryRun && !parsingStdin && parseStdinAsOptions) {
+            String[] stdinArgv = readStdinAsArgv();
+            if (0 != stdinArgv.length) {
+                parse(stdinArgv, true, dryRun);
+            }
+        }
+
         return arg;
+    }
+
+    private String[] readStdinAsArgv() throws IOException {
+        List<String> stdinArgvList = new ArrayList<String>();
+
+        BufferedReader in = UTF8.bufferedReader(System.in);
+        while (true) {
+            String s = in.readLine();
+            if (s == null) {
+                break;
+            }
+            stdinArgvList.add(s);
+        }
+        in.close();
+
+        String[] stdinArgv = stdinArgvList.toArray(new String[stdinArgvList.size()]);
+        return stdinArgv;
     }
 
     /**


### PR DESCRIPTION
Here's a maintainable way forward to allow any findbugs ant task  (or command-line user) to specify large values or many arguments.   I started with the idea used by -auxclasspathFromInput and expanded it to be more generic so that it could work for any option.   Options are parsed from the command-line and if -parseStdinAsOptions is specified, options are then parsed from standard input, which each line considered as a separate argument.   Since sourcePath was the option which was not working for me in the findbugs ant task, I updated both it and auxClasspath to use this new mechanism from the ant task.   It is a simple matter to apply the same change to other options.  Candidates could include  class, visitors, and my proposed excludePath and includePath elements.    This change maintains backward compatibility although the use of -parseStdinAsOptions will be incompatible with anything else using standard input. 
