### PR TITLE
Fix typos (only in comments and documentation)

### DIFF
--- a/eclipsePlugin/doc/building_findbugsplugin.txt
+++ b/eclipsePlugin/doc/building_findbugsplugin.txt
@@ -7,7 +7,7 @@ Make sure you are using Java 7 or greater (since version 3.0 FindBugs requires J
 
 Install Eclipse
 ================
-1) Download and install Eclipse 3.6.+ (minumum supported version).
+1) Download and install Eclipse 3.6.+ (minimum supported version).
 2) Download and install EGit plugin for Git.
     Chose [Help | Software Updates... | Available Software | Add Site...] and use
     http://download.eclipse.org/egit/updates as update site url. Select both checkboxes

--- a/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/builder/WorkItem.java
@@ -342,7 +342,7 @@ public class WorkItem {
     /**
      *
      * @return full absolute path corresponding to the work item (file or
-     *         directory). If the work item is a part of an achive, it's the
+     *         directory). If the work item is a part of an archive, it's the
      *         path to the archive file. If the work item is a project, it's the
      *         path to the project root. TODO If the work item is an internal
      *         java element (method, inner class etc), results are undefined

--- a/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
+++ b/eclipsePlugin/src/de/tobject/findbugs/properties/DetectorConfigurationTab.java
@@ -134,7 +134,7 @@ public class DetectorConfigurationTab extends Composite {
             }
             result = s1.compareTo(s2);
 
-            // second sort if elements are equals - on only 2 criterias
+            // second sort if elements are equals - on only 2 criteria
             if (result == 0) {
                 switch (getSortColumnId()) {
                 case DETECTOR_NAME:
@@ -422,7 +422,7 @@ public class DetectorConfigurationTab extends Composite {
         String detailHTML = factory.getDetailHTML();
         // cut beginning and the end of the html document
         detailHTML = trimHtml(detailHTML, "<BODY>", "</BODY>");
-        // replace any amount of white space with newline inbetween through one
+        // replace any amount of white space with newline between through one
         // space
         detailHTML = detailHTML.replaceAll("\\s*[\\n]+\\s*", " ");
         // remove all valid html tags

--- a/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
+++ b/eclipsePlugin/src/edu/umd/cs/findbugs/plugin/eclipse/quickfix/util/ASTUtil.java
@@ -68,7 +68,7 @@ import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.StatementNotFoundEx
 import edu.umd.cs.findbugs.plugin.eclipse.quickfix.exception.TypeDeclarationNotFoundException;
 
 /**
- * The <CODE>ASTUtil</CODE> provides some usefull methods to transform
+ * The <CODE>ASTUtil</CODE> provides some useful methods to transform
  * <CODE>PackageMemberAnnotations</CODE> into <CODE>BodyDeclarations</CODE>.
  * Normally this methods should be used to get a type, field or method
  * declaration for a class, field or method annotation.

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -59,7 +59,7 @@ import edu.umd.cs.findbugs.ExitCodes;
  * <li>maxRank (maximum rank issue to be reported)
  * <li>jvm (Set the command used to start the VM)
  * <li>jvmargs (any additional jvm arguments)
- * <li>omitVisitors (collection - comma seperated)
+ * <li>omitVisitors (collection - comma separated)
  * <li>onlyAnalyze (restrict analysis to find bugs to given comma-separated list
  * of classes and packages - See the textui argument description for details)
  * <li>output (enum text|xml|xml:withMessages|html - default xml)
@@ -78,7 +78,7 @@ import edu.umd.cs.findbugs.ExitCodes;
  * "default.xsl")
  * <li>systemProperty (a system property to set)
  * <li>timestampNow (boolean - default false)
- * <li>visitors (collection - comma seperated)
+ * <li>visitors (collection - comma separated)
  * <li>chooseVisitors (selectively enable/disable visitors)
  * <li>workHard (boolean default false)
  * <li>setSetExitCode (boolean default true)

--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsViewerTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsViewerTask.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.ExitCodes;
 /**
  * FindBugsViewerTask.java -- Ant Task to launch the FindBugsFrame
  *
- * To use, create a new task that refrences the ant task (such as
+ * To use, create a new task that references the ant task (such as
  * "findbugs-viewer"). Then call this task while passing in parameters to modify
  * it's behaviour. It supports several options that are the same as the findbugs
  * task:

--- a/findbugs/src/doc/Changes.html
+++ b/findbugs/src/doc/Changes.html
@@ -706,7 +706,7 @@
                 <p>Changes since version 1.3.5</p>
                 <ul>
                     <li>Added fairly exhaustive static analysis of uses of format
-                        strings, checking for missing or extra arguements, invalid format
+                        strings, checking for missing or extra arguments, invalid format
                         specifiers, or mismatched format specifiers and arguments (e.g,
                         passing a String value for a %d format specifier). The logic for
                         doing so is derived from Sun's java.util.Formatter class, and
@@ -1304,7 +1304,7 @@
                                         extends <code>beta.Foo</code>). This can be exceptionally
                                         confusing, create lots of situations in which you have to look
                                         at import statements to resolve references and creates many
-                                        opportunities to accidently define methods that do not
+                                        opportunities to accidentally define methods that do not
                                         override methods in their superclasses.
                                     </li>
                                     <li>NM_SAME_SIMPLE_NAME_AS_INTERFACE: This class/interface
@@ -1313,7 +1313,7 @@
                                         in a different package (e.g., <code>alpha.Foo</code> extends <code>beta.Foo</code>).
                                         This can be exceptionally confusing, create lots of situations
                                         in which you have to look at import statements to resolve
-                                        references and creates many opportunities to accidently define
+                                        references and creates many opportunities to accidentally define
                                         methods that do not override methods in their superclasses.
                                     </li>
                                 </ul>
@@ -2130,10 +2130,10 @@
                     </li>
                     <li>Updated detectors
                         <ul>
-                            <li>SwitchFallthrough.java: surpress some false positives</li>
-                            <li>DuplicateBranches.java: surpress some false positives</li>
-                            <li>IteratorIdioms.java: surpress some false positives</li>
-                            <li>FindHEmismatch.java: surpress some false positives</li>
+                            <li>SwitchFallthrough.java: suppress some false positives</li>
+                            <li>DuplicateBranches.java: suppress some false positives</li>
+                            <li>IteratorIdioms.java: suppress some false positives</li>
+                            <li>FindHEmismatch.java: suppress some false positives</li>
                             <li>QuestionableBooleanAssignment.java: finds more cases of
                                 <tt>if (b=true)</tt> ilk
                             </li>
@@ -2444,7 +2444,7 @@
                     <li>New detector to find calls to equals() methods that use
                         Object's version. (Dave Brosius)</li>
                     <li>New detector to find Applets that call methods in the
-                        constructor refering to the AppletStub (Dave Brosius)</li>
+                        constructor referring to the AppletStub (Dave Brosius)</li>
                     <li>New detector to find some cases of infinite recursion
                         (Bill Pugh)</li>
                     <li>New detector to find dead stores to local variables (David
@@ -2498,7 +2498,7 @@
                     <li>Allow Swing GUI to show source code in jar files on
                         Windows systems (Dave Brosius) <!-- Bug fixes -->
                     </li>
-                    <li>Fix the Switch Fall Thru detector (Dave Brosius, David
+                    <li>Fix the Switch Fall Through detector (Dave Brosius, David
                         Hovemeyer, Bill Pugh)</li>
                     <li>MacOS GUI fixes (Rohan Lloyd)</li>
                     <li>Fix false positive in BOA in case where method is

--- a/findbugs/src/doc/manual.xml
+++ b/findbugs/src/doc/manual.xml
@@ -1335,7 +1335,7 @@ using the &FindBugs; task.
        <para>
        An optional attribute.  It specifies
        the confidence/priority threshold for reporting issues.  If set to "low", confidence is not used to filter bugs.
-       If set to "medium" (the default), low confidence issues are supressed.
+       If set to "medium" (the default), low confidence issues are suppressed.
        If set to "high", only high confidence bugs are reported.
        </para>
     </listitem>
@@ -2058,7 +2058,7 @@ In other words, each of the children must be true for the predicate to be true.
             If the <literal>Match</literal> element contains neither a <literal>Class</literal> element,
             nor a <literal>class</literal> / <literal>classregex</literal> attribute, the predicate will apply
             to all classes. Such predicate is likely to match more bug instances than you want, unless it is
-            refined further down with apropriate method or field predicates.
+            refined further down with appropriate method or field predicates.
         </para>
     </listitem>
  </varlistentry>
@@ -2096,7 +2096,7 @@ In other words, each of the children must be true for the predicate to be true.
 
    <listitem><para>This element specifies a field. The <literal>name</literal> attribute is is used to specify
    the exact or regex match pattern for the field name. You can also filter fields according to their signature -
-   use <literal>type</literal> attribute to specify fully qualified type of the field. You can specify eiter or both
+   use <literal>type</literal> attribute to specify fully qualified type of the field. You can specify either or both
    of these attributes in order to perform name / signature based matches. The <literal>role</literal> attribute is
    the field role.
    </para></listitem>
@@ -2191,7 +2191,7 @@ two <literal>Match</literal> clauses:
 By explicitly matching both classes, you ensure that the IC bug instance will be
 matched regardless of which class involved in the circularity happens to be
 listed first in the bug instance.  (Of course, this approach might accidentally
-supress circularities involving "com.foobar.A" or "com.foobar.B" and a third
+suppress circularities involving "com.foobar.A" or "com.foobar.B" and a third
 class.)
 </para>
 
@@ -2632,7 +2632,7 @@ When this annotation is applied to a method it applies to the method return valu
           </listitem>
           <listitem>
             <para>
-              <command>explanation:</command>A textual explaination of why the return value should be checked. Default value:"".
+              <command>explanation:</command>A textual explanation of why the return value should be checked. Default value:"".
             </para>
           </listitem>
         </varlistentry>
@@ -2799,7 +2799,7 @@ Annotated fields must not be null after construction has completed. Annotated me
       <para>
 The annotated element could be null under some circumstances. In general, this means
 developers will have to read the documentation to determine when a null value is
-acceptable and whether it is neccessary to check for a null value.  FindBugs will
+acceptable and whether it is necessary to check for a null value.  FindBugs will
 treat the annotated items as though they had no annotation.
       </para>
       <para>
@@ -3207,7 +3207,7 @@ To specify input files, nest them inside with a
                   <tbody>
 <row><entry>-output &lt;file&gt;</entry>           <entry>output="&lt;file&gt;"</entry>           <entry>save output in the named file (may also be an input file)</entry></row>
 <row><entry>-overrideRevisionNames[:truth]</entry> <entry>overrideRevisionNames="[true|false]"</entry><entry>override revision names for each version with names computed from the filenames</entry></row>
-<row><entry>-noPackageMoves[:truth]</entry>        <entry>noPackageMoves="[true|false]"</entry><entry>if a class has moved to another package, treat warnings in that class as seperate</entry></row>
+<row><entry>-noPackageMoves[:truth]</entry>        <entry>noPackageMoves="[true|false]"</entry><entry>if a class has moved to another package, treat warnings in that class as separate</entry></row>
 <row><entry>-preciseMatch[:truth]</entry>          <entry>preciseMatch="[true|false]"</entry><entry>require bug patterns to match precisely</entry></row>
 <row><entry>-precisePriorityMatch[:truth]</entry>  <entry>precisePriorityMatch="[true|false]"</entry><entry>consider two warnings as the same only if priorities match exactly</entry></row>
 <row><entry>-quiet[:truth]</entry>                 <entry>quiet="[true|false]"</entry><entry>don't generate any output to standard out unless there is an error</entry></row>
@@ -3383,7 +3383,7 @@ attribute or nest it inside the ant call with a
                       <row><entry>fixed</entry><entry>Count of warnings removed from a class that remains in the current version</entry></row>
                       <row><entry>removed</entry><entry>Count of warnings in the previous version for a class that is not present in the current version</entry></row>
                       <row><entry>retained</entry><entry>Count of warnings that were in both the previous and current version</entry></row>
-                      <row><entry>dead</entry><entry>Warnings that were present in earlier versions but in neither the current version or the immediately preceeding version</entry></row>
+                      <row><entry>dead</entry><entry>Warnings that were present in earlier versions but in neither the current version or the immediately preceding version</entry></row>
                       <row><entry>active</entry><entry>Total warnings present in the current version</entry></row>
                 </tbody>
                 </tgroup>

--- a/findbugs/src/doc/sysprops.html
+++ b/findbugs/src/doc/sysprops.html
@@ -68,7 +68,7 @@ gives information if the field is set to true.
 	</tr>
 	<tr>
 		<td>findbugs.sf.comment</td>
-		<td>Ignore switch fall thru bugs if a comment is found with 'fall' or 'nobreak'
+		<td>Ignore switch fall through bugs if a comment is found with 'fall' or 'nobreak'
 	</tr>
 	<tr>
 		<td>ba.checkAssertions</td>

--- a/findbugs/src/doc/updateChecking.html
+++ b/findbugs/src/doc/updateChecking.html
@@ -60,13 +60,13 @@ already moved to findbugs/plugin, and the webCloudClient.jar plug in the optiona
 <li>You can also redirect all update checks to a local server. This allows you to collect information about who is using
 what versions of FindBugs in your organization, and keep all of that information private.
 <li>All of the plugins from the FindBugs project use <pre>http://update.findbugs.org/update-check</pre> as the 
-host we use for update checks. If you wish to ensure that no one from your organization accidently reports any usage
+host we use for update checks. If you wish to ensure that no one from your organization accidentally reports any usage
 information to the FindBugs project, you can blacklist that URL in your firewall 
 <ul>
 <li>You can also block <pre>http://findbugs-cloud.appspot.com</pre>, the host we use for our publicly hosted
 repository of bug evaluations (e.g., evaluations in open source projects such as the JDK, Eclipse and GlassFish).
 While people have to explicitly request that their evaluations be stored into the FindBugs cloud, you 
-can block it to ensure that no one accidently shares evaluations of your own code to the FindBugs cloud. You can also
+can block it to ensure that no one accidentally shares evaluations of your own code to the FindBugs cloud. You can also
 remove the WebCloudClient 
 
 </ul>

--- a/findbugs/src/doc/users.html
+++ b/findbugs/src/doc/users.html
@@ -54,7 +54,7 @@
 					<p>
 						The following companies, projects and organizations have given us
 						permission to identify them as FindBugs users and/or have
-						publically stated that they use FindBugs. Send email to
+						publicly stated that they use FindBugs. Send email to
 						<a href="mailto:findbugs@cs.umd.edu">findbugs@cs.umd.edu</a> if
 						you'd like to be listed here.
 					</p>

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/GUISaveState.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/GUISaveState.java
@@ -53,7 +53,7 @@ import edu.umd.cs.findbugs.SystemProperties;
  *
  */
 /*
- * GUISaveState uses the Preferences API, dont look for a file anywhere, there
+ * GUISaveState uses the Preferences API, don't look for a file anywhere, there
  * isn't one, well... there might be, but its all system dependent where it is
  * and how its stored
  */

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrame.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrame.java
@@ -544,7 +544,7 @@ public class MainFrame extends FBFrame implements LogSync {
         if (bugCollection != null) {
             displayer.clearCache();
             BugSet bs = new BugSet(bugCollection);
-            // Dont clear data, the data's correct, just get the tree off the
+            // Don't clear data, the data's correct, just get the tree off the
             // listener lists.
             BugTreeModel model = (BugTreeModel) mainFrameTree.getTree().getModel();
             model.getOffListenerList();

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrameTree.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/MainFrameTree.java
@@ -633,7 +633,7 @@ public class MainFrameTree implements Serializable {
                     if (!(path.getParentPath() == null)) {
                         // path is null, the
                         // root was selected,
-                        // dont allow them to
+                        // don't allow them to
                         // filter out the root.
                         branchPopupMenu.show(tree, e.getX(), e.getY());
                     }

--- a/findbugs/src/gui/edu/umd/cs/findbugs/gui2/StackedFilterMatcher.java
+++ b/findbugs/src/gui/edu/umd/cs/findbugs/gui2/StackedFilterMatcher.java
@@ -134,7 +134,7 @@ public class StackedFilterMatcher extends FilterMatcher {
                 (MainFrame.getInstance().getBugTreeModel()).sendEvent(event, whatToDo);
             } catch (BranchOperationException e) {
                 // Another filter already filters out the branch this filter
-                // would filter out, set active, but dont send any tree model
+                // would filter out, set active, but don't send any tree model
                 // events.
                 this.active = active;
             }

--- a/findbugs/src/java/edu/umd/cs/findbugs/BugRanker.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/BugRanker.java
@@ -51,7 +51,7 @@ import edu.umd.cs.findbugs.util.Util;
  *
  * A bug ranker is comprised of a list of bug patterns, bug kinds and bug
  * categories. For each, either an absolute or relative bug rank is provided. A
- * relative rank is one preceeded by a + or -.
+ * relative rank is one preceded by a + or -.
  *
  * For core bug detectors, the bug ranker search order is:
  * <ul>

--- a/findbugs/src/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/FuzzyBugComparator.java
@@ -277,7 +277,7 @@ public class FuzzyBugComparator implements WarningComparator {
     }
 
     /**
-     * For now, just look at the 2 preceeding and succeeding opcodes for fuzzy
+     * For now, just look at the 2 preceding and succeeding opcodes for fuzzy
      * source line matching.
      */
     //    private static final int NUM_CONTEXT_OPCODES = 2;

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/PruneInfeasibleExceptionEdges.java
@@ -61,7 +61,7 @@ public class PruneInfeasibleExceptionEdges implements EdgeTypes {
     }
 
     /**
-     * A momento to remind us of how we classified a particular exception edge.
+     * A memento to remind us of how we classified a particular exception edge.
      * If pruning and classifying succeeds, then these momentos can be applied
      * to actually change the state of the edges. The issue is that the entire
      * pruning/classifying operation must either fail or succeed as a whole.

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/RepositoryClassParser.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/RepositoryClassParser.java
@@ -69,7 +69,7 @@ public class RepositoryClassParser {
     }
 
     /**
-     * Parse the class file into a JavaClass object. If succesful, the new
+     * Parse the class file into a JavaClass object. If successful, the new
      * JavaClass is entered into the Repository.
      *
      * @return the parsed JavaClass

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/BindingSet.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/BindingSet.java
@@ -20,7 +20,7 @@
 package edu.umd.cs.findbugs.ba.bcp;
 
 /**
- * A set of Bindings, which are definitions of variables occuring in a
+ * A set of Bindings, which are definitions of variables occurring in a
  * ByteCodePattern. BindingSets are immutable; to add a binding, a new cell is
  * allocated. (Are we CONSING yet?)
  *

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/bcp/FieldAccess.java
@@ -65,7 +65,7 @@ public abstract class FieldAccess extends SingleInstruction implements org.apach
      * @param bindingSet
      *            previous definitions
      * @return a MatchResult containing an updated BindingSet if successful, or
-     *         null if unsucessful
+     *         null if unsuccessful
      */
     protected MatchResult checkConsistent(Variable field, Variable value, BindingSet bindingSet) {
         // Ensure that the field and value variables are consistent with

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/npe/NullDerefAndRedundantComparisonFinder.java
@@ -69,7 +69,7 @@ import edu.umd.cs.findbugs.log.Profiler;
 
 /**
  * A user-friendly front end for finding null pointer dereferences and redundant
- * null comparisions.
+ * null comparisons.
  *
  * @see IsNullValueAnalysis
  * @author David Hovemeyer

--- a/findbugs/src/java/edu/umd/cs/findbugs/config/SortedProperties.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/config/SortedProperties.java
@@ -32,7 +32,7 @@ public final class SortedProperties extends Properties {
      *
      * @param keySet
      *            non null set instance to sort
-     * @return non null list wich contains all given keys, sorted
+     * @return non null list which contains all given keys, sorted
      *         lexicographically. The list may be empty if given set was empty
      */
     static public Enumeration<?> sortKeys(Set<String> keySet) {

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/MutableStaticFields.java
@@ -122,7 +122,7 @@ public class MutableStaticFields extends BytecodeScanningDetector {
 
     /**
      * Eclipse uses reflection to initialize NLS message bundles. Classes which
-     * using this mechanism are usualy extending org.eclipse.osgi.util.NLS class
+     * using this mechanism are usually extending org.eclipse.osgi.util.NLS class
      * and contains lots of public static String fields which are used as
      * message constants. Unfortunately these fields cannot be final, so FB
      * reports tons of warnings for such Eclipse classes.

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/Naming.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/Naming.java
@@ -378,7 +378,7 @@ public class Naming extends PreorderVisitor implements Detector {
 
     /**
      * Eclipse uses reflection to initialize NLS message bundles. Classes which
-     * using this mechanism are usualy extending org.eclipse.osgi.util.NLS class
+     * using this mechanism are usually extending org.eclipse.osgi.util.NLS class
      * and contains lots of public static String fields which are used as
      * message constants. Unfortunately these fields often has bad names which
      * does not follow Java code convention, so FB reports tons of warnings for

--- a/findbugs/src/java/edu/umd/cs/findbugs/filter/NameMatch.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/filter/NameMatch.java
@@ -34,7 +34,7 @@ import edu.umd.cs.findbugs.util.Util;
  * String and null)
  *
  * If matchSpec starts with ~ character it will be treated as
- * java.util.regex.Pattern, with the ~ character omited. The pattern will be
+ * java.util.regex.Pattern, with the ~ character omitted. The pattern will be
  * matched against whole value (ie Matcher.match(), not Matcher.find())
  *
  * If matchSpec is a non-null String with any other initial charcter, exact

--- a/findbugs/src/java/edu/umd/cs/findbugs/jaif/JAIFScanner.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/jaif/JAIFScanner.java
@@ -55,7 +55,7 @@ public class JAIFScanner {
     }
 
     // See http://java.sun.com/docs/books/jls/third_edition/html/lexical.html
-    // Hexidecimal floating-point literals are not implemented.
+    // Hexadecimal floating-point literals are not implemented.
     // Unicode escapes are not implemented (but could be implemented in the
     // fillLineBuf() method).
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/plan/ConstraintEdge.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/plan/ConstraintEdge.java
@@ -57,7 +57,7 @@ public class ConstraintEdge extends AbstractEdge<ConstraintEdge, DetectorNode> {
 
     /**
      * Determine whether or not this ConstraintEdge resulted from an ordering
-     * constraint having a single detector as its source (ealier detector). Such
+     * constraint having a single detector as its source (earlier detector). Such
      * constraints automatically enable the source (earlier) detector if the
      * target (later) detector is enabled.
      *

--- a/findbugs/src/java/edu/umd/cs/findbugs/plan/DetectorOrderingConstraint.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/plan/DetectorOrderingConstraint.java
@@ -41,7 +41,7 @@ public class DetectorOrderingConstraint {
 
     /**
      * Set whether or not this ordering constraint resulted from an ordering
-     * constraint having a single detector as its source (ealier detector). Such
+     * constraint having a single detector as its source (earlier detector). Such
      * constraints automatically enable the source (earlier) detector if the
      * target (later) detector is enabled.
      */
@@ -51,7 +51,7 @@ public class DetectorOrderingConstraint {
 
     /**
      * Determine whether or not this ordering constraint resulted from an
-     * ordering constraint having a single detector as its source (ealier
+     * ordering constraint having a single detector as its source (earlier
      * detector). Such constraints automatically enable the source (earlier)
      * detector if the target (later) detector is enabled.
      *

--- a/findbugs/src/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/workflow/MineBugHistory.java
@@ -404,7 +404,7 @@ public class MineBugHistory {
     }
 
     /**
-     * Get key used to classify the presence and/or abscence of a BugInstance in
+     * Get key used to classify the presence and/or absence of a BugInstance in
      * successive versions in the history.
      *
      * @param activePrevious

--- a/findbugsTestCases/src/java/ITest.java
+++ b/findbugsTestCases/src/java/ITest.java
@@ -9,7 +9,7 @@ public class ITest {
     public boolean compareDoNotReport(A first, B second) {
         // It is possible that "first" is an instance of
         // a class that implements B. Therefore, it
-        // is possible that the comparision can be true,
+        // is possible that the comparison can be true,
         // so we shouldn't report.
         return first.equals(second);
     }

--- a/findbugsTestCases/src/java/UselessSCMethods.java
+++ b/findbugsTestCases/src/java/UselessSCMethods.java
@@ -34,7 +34,7 @@ public class UselessSCMethods extends Super {
     }
 
     @Override
-    public void test4(String s) { // don't report this, altho suspect, access
+    public void test4(String s) { // don't report this, although suspect, access
                                   // has been widened
         // perhaps this should be reported as another bug type, dunno
         super.test4(s);

--- a/findbugsTestCases/src/java/sfBugs/Bug1765893.java
+++ b/findbugsTestCases/src/java/sfBugs/Bug1765893.java
@@ -7,7 +7,7 @@ import java.util.Date;
  * Submitted By: Alfred Nathaniel Summary:
  * 
  * The STCAL_STATIC_SIMPLE_DATE_FORMAT_INSTANCE detector is too simple minded
- * checking only the field existance but not its usage.
+ * checking only the field existence but not its usage.
  */
 public class Bug1765893 {
     private static final SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");

--- a/sandbox/localCloud/war/js/openid-jquery.js
+++ b/sandbox/localCloud/war/js/openid-jquery.js
@@ -2,7 +2,7 @@
 Simple OpenID Plugin
 http://code.google.com/p/openid-selector/
 
-This code is licenced under the New BSD License.
+This code is licensed under the New BSD License.
 */
 
 var providers_large = {


### PR DESCRIPTION
All of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>