### PR TITLE
Ignore PZLA_PREFER_ZERO_LENGTH_ARRAYS if method is annotated with @CheckForNull

### DIFF
--- a/findbugs/etc/messages.xml
+++ b/findbugs/etc/messages.xml
@@ -5400,7 +5400,7 @@ closed.</p>
     </Details>
   </BugPattern>
   <BugPattern type="PZLA_PREFER_ZERO_LENGTH_ARRAYS">
-    <ShortDescription>Consider returning a zero length array rather than null</ShortDescription>
+    <ShortDescription>Consider returning a zero length array rather than null or using @CheckForNull annotation</ShortDescription>
     <LongDescription>Should {1} return a zero length array rather than null?</LongDescription>
     <Details>
 <![CDATA[
@@ -5413,7 +5413,8 @@ This way, no explicit check for null is needed by clients of the method.</p>
 "there is no answer to this question" is probably appropriate.
 For example, <code>File.listFiles()</code> returns an empty list
 if given a directory containing no files, and returns null if the file
-is not a directory.</p>
+is not a directory.
+It is generally a good idea to annotate such method with <code>@CheckForNull</code>.</p>
 ]]>
     </Details>
   </BugPattern>

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/ClassContext.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/ClassContext.java
@@ -46,7 +46,6 @@ import org.apache.bcel.generic.MethodGen;
 import edu.umd.cs.findbugs.AnalysisLocal;
 import edu.umd.cs.findbugs.OpcodeStack.JumpInfo;
 import edu.umd.cs.findbugs.SystemProperties;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import edu.umd.cs.findbugs.ba.ca.CallListDataflow;
 import edu.umd.cs.findbugs.ba.constant.ConstantDataflow;
 import edu.umd.cs.findbugs.ba.deref.UnconditionalValueDerefDataflow;
@@ -550,7 +549,6 @@ public class ClassContext {
      *         code
      */
     @CheckForNull
-    @SuppressFBWarnings("PZLA_PREFER_ZERO_LENGTH_ARRAYS")
     public short[] getOffsetToOpcodeMap(Method method) {
         UnpackedCode unpackedCode = getMethodAnalysisNoException(UnpackedCode.class, method);
         return unpackedCode != null ? unpackedCode.getOffsetToBytecodeMap() : null;

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/PreferZeroLengthArrays.java
@@ -29,6 +29,11 @@ import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.BytecodeScanningDetector;
 import edu.umd.cs.findbugs.SourceLineAnnotation;
 import edu.umd.cs.findbugs.StatelessDetector;
+import edu.umd.cs.findbugs.ba.AnalysisContext;
+import edu.umd.cs.findbugs.ba.NullnessAnnotation;
+import edu.umd.cs.findbugs.ba.XFactory;
+import edu.umd.cs.findbugs.ba.XMethod;
+import edu.umd.cs.findbugs.ba.npe.TypeQualifierNullnessAnnotationDatabase;
 
 public class PreferZeroLengthArrays extends BytecodeScanningDetector implements StatelessDetector {
     boolean nullOnTOS = false;
@@ -50,7 +55,7 @@ public class PreferZeroLengthArrays extends BytecodeScanningDetector implements 
             return;
         }
         String returnType = getMethodSig().substring(getMethodSig().indexOf(')') + 1);
-        if (returnType.startsWith("[")) {
+        if (returnType.startsWith("[") && !isCheckForNull()) {
             nullOnTOS = false;
             super.visit(obj);
             if (!found.isEmpty()) {
@@ -62,6 +67,13 @@ public class PreferZeroLengthArrays extends BytecodeScanningDetector implements 
                 found.clear();
             }
         }
+    }
+
+    private boolean isCheckForNull() {
+        XMethod m = XFactory.createXMethod(getClassContext().getJavaClass(), getMethod());
+        TypeQualifierNullnessAnnotationDatabase nullnessDb = AnalysisContext.currentAnalysisContext().getNullnessAnnotationDatabase();
+        NullnessAnnotation nullness = nullnessDb.getResolvedAnnotation(m, false);
+        return NullnessAnnotation.CHECK_FOR_NULL.equals(nullness);
     }
 
     @Override

--- a/findbugs/src/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/visitclass/AnnotationVisitor.java
@@ -33,7 +33,6 @@ import org.apache.bcel.classfile.ParameterAnnotations;
 import org.apache.bcel.classfile.SimpleElementValue;
 
 import edu.umd.cs.findbugs.SystemProperties;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.util.ClassName;
 
@@ -82,7 +81,6 @@ public class AnnotationVisitor extends PreorderVisitor {
     }
 
     @CheckForNull
-    @SuppressFBWarnings("PZLA_PREFER_ZERO_LENGTH_ARRAYS")
     protected static String[] getAnnotationParameterAsStringArray(Map<String, ElementValue> map, String parameter) {
         try {
             ElementValue e = map.get(parameter);

--- a/findbugsTestCases/src/java/PreferZeroLengthArrays.java
+++ b/findbugsTestCases/src/java/PreferZeroLengthArrays.java
@@ -1,3 +1,5 @@
+import javax.annotation.CheckForNull;
+
 class PreferZeroLengthArrays {
 
     public int[] foo(int i) {
@@ -6,5 +8,10 @@ class PreferZeroLengthArrays {
 
     public int[] bar(int i) {
         return new int[0];
+    }
+
+    @CheckForNull
+    public int[] fooCheckForNull(int i) {
+        return null;
     }
 }


### PR DESCRIPTION
`@CheckForNull` on a method indicates that the method is designed to return null, so `PZLA_PREFER_ZERO_LENGTH_ARRAYS` warning does not make sense for such a method.

I manually tested this change on my code and on `PreferZeroLengthArrays` in `findbugsTestCases`.  I did not figure out how to run JUnit against `findbugsTestCases/.../PreferZeroLengthArrays`

I am not familiar with the findbugs code, so if this change is accepted somebody should review my `isCheckForNull()` method - it may not be the best way to figure out whether or not a method is annotated with `@CheckForNull`.  Moreover it does not work if the class rather than the method has the `@CheckForNull` annotation.  I expected that `getResolvedAnnotation()` would find the class annotation, but maybe that's how it's supposed to work.
