### PR TITLE
Update JavaVersion for JEP 223 compatibility

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/JavaVersion.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/JavaVersion.java
@@ -26,7 +26,10 @@ import java.util.regex.Pattern;
  * Support for finding out what version of Java we're running on.
  */
 public class JavaVersion {
-    private static final Pattern PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)(\\..*)?$");
+
+    private static final String MAJMIN   = "([1-9][0-9]*(?:(?:\\.0)|(?:\\.[1-9][0-9]*))?)";
+    private static final String REST     = "([_\\-a-zA-Z0-9\\.\\+]*)";
+    private static final Pattern PATTERN = Pattern.compile("^" + MAJMIN + REST + "$");
 
     private final int major;
 
@@ -68,10 +71,11 @@ public class JavaVersion {
             throw new JavaVersionException("Could not parse Java version string: " + versionString);
         }
         try {
-            major = Integer.parseInt(matcher.group(1));
-            minor = Integer.parseInt(matcher.group(2));
-            if (matcher.group(3) != null) {
-                rest = matcher.group(3);
+            String[] vnum = matcher.group(1).split("\\.");
+            major = Integer.parseInt(vnum[0]);
+            minor = Integer.parseInt(vnum.length > 1 ? vnum[1] : "0");
+            if (matcher.group(2) != null) {
+                rest = matcher.group(2);
             } else {
                 rest = "";
             }

--- a/findbugs/src/junit/edu/umd/cs/findbugs/JavaVersionTest.java
+++ b/findbugs/src/junit/edu/umd/cs/findbugs/JavaVersionTest.java
@@ -1,0 +1,56 @@
+/*
+ * FindBugs - Find Bugs in Java programs
+ * Copyright (C) 2003-2008 University of Maryland
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package edu.umd.cs.findbugs;
+
+import junit.framework.TestCase;
+
+public class JavaVersionTest extends TestCase {
+
+    private static void testJavaVersionString(String version, int maj, int min, String rest)
+            throws JavaVersionException {
+        JavaVersion jv = new JavaVersion(version);
+        assertEquals(maj, jv.getMajor());
+        assertEquals(min, jv.getMinor());
+        assertEquals(rest, jv.getRest());
+    }
+
+    /**
+     * Test method for {@link edu.umd.cs.findbugs.JavaVersion#JavaVersion(java.lang.String)}.
+     * @throws JavaVersionException if version string cannot be parsed
+     */
+    public void testJavaVersionString() throws JavaVersionException {
+        // Historical versions (up to Java 8)
+        testJavaVersionString("1.7", 1, 7, "");
+        testJavaVersionString("1.7.0", 1, 7, ".0");
+        testJavaVersionString("1.7.0_80", 1, 7, ".0_80");
+        testJavaVersionString("1.8.0_66", 1, 8, ".0_66");
+        // New scheme for Java 9 and later (JEP 223)
+        // See http://openjdk.java.net/jeps/223
+        testJavaVersionString("9-ea",  9, 0, "-ea");
+        testJavaVersionString("9",     9, 0, "");
+        testJavaVersionString("9.1.2", 9, 1, ".2");
+        testJavaVersionString("9.0.1", 9, 0, ".1");
+        // Long versions
+        testJavaVersionString("1.7.0_65-b20", 1, 7, ".0_65-b20");
+        testJavaVersionString("7.6.15+20", 7, 6, ".15+20");
+        testJavaVersionString("1.9.0-ea-b19", 1, 9, ".0-ea-b19");
+        testJavaVersionString("9-ea+19", 9, 0, "-ea+19");
+    }
+}


### PR DESCRIPTION
JEP 223 introduces a new version scheme for Java versions >= 9:

http://openjdk.java.net/jeps/223

This fixes https://sourceforge.net/p/findbugs/bugs/1432