### PR TITLE
Fix nonnull annotations database for java.util.concurrent.ForkJoinPool

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/DefaultNullnessAnnotations.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/DefaultNullnessAnnotations.java
@@ -190,7 +190,9 @@ public class DefaultNullnessAnnotations {
         database.addMethodParameterAnnotation("java.util.concurrent.ConcurrentHashMap", "setEntryAt",
                 "([Ljava/util/concurrent/ConcurrentHashMap$HashEntry;ILjava/util/concurrent/ConcurrentHashMap$HashEntry;)V", false, 1, NullnessAnnotation.NULLABLE);
         database.addMethodParameterAnnotation("java.util.concurrent.ForkJoinPool", "<init>",
-                "(ILjava/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory;Ljava/lang/Thread$UncaughtExceptionHandler;Z)V", false, 1, NullnessAnnotation.NULLABLE);
+                "(ILjava/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory;Ljava/lang/Thread$UncaughtExceptionHandler;Z)V", false, 1, NullnessAnnotation.NONNULL);
+        database.addMethodParameterAnnotation("java.util.concurrent.ForkJoinPool", "<init>",
+                "(ILjava/util/concurrent/ForkJoinPool$ForkJoinWorkerThreadFactory;Ljava/lang/Thread$UncaughtExceptionHandler;Z)V", false, 2, NullnessAnnotation.NULLABLE);
         database.addMethodParameterAnnotation("java.util.concurrent.PriorityBlockingQueue", "<init>",
                 "(ILjava/util/Comparator;)V", false, 1, NullnessAnnotation.NULLABLE);
 

--- a/findbugsTestCases/src/java/ghIssues/Issue0076.java
+++ b/findbugsTestCases/src/java/ghIssues/Issue0076.java
@@ -1,0 +1,27 @@
+package ghIssues;
+
+import java.io.Serializable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+import edu.umd.cs.findbugs.annotations.NoWarning;
+
+public class Issue0076 {
+
+    private static class Handler implements Thread.UncaughtExceptionHandler {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+        }
+    }
+    
+    @NoWarning("NP_NONNULL_PARAM_VIOLATION")
+    public void testNominal() {
+        new ForkJoinPool(2, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true);
+    }
+
+    @ExpectWarning("NP_NONNULL_PARAM_VIOLATION")
+    public void testWarning() {
+        new ForkJoinPool(2, null, new Handler(), true);
+    }
+}


### PR DESCRIPTION
The current definition of ForkJoinPool leads to a false positive if parameter 3 (handler) is null.

This is explicitely valid in Oracle documentation:
https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ForkJoinPool.html#ForkJoinPool(int,%20java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory,%20java.lang.Thread.UncaughtExceptionHandler,%20boolean)