### PR TITLE
Update UnreadFields.java

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/UnreadFields.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/UnreadFields.java
@@ -781,8 +781,8 @@ public class UnreadFields extends OpcodeStackDetector {
             boolean isConstructor = "<init>".equals(getMethodName()) || "<clinit>".equals(getMethodName());
             if (getMethod().isStatic() == f.isStatic()
                     && (isConstructor || data.calledFromConstructors.contains(getMethodName() + ":" + getMethodSig())
-                            || "init".equals(getMethodName()) || "init".equals(getMethodName())
-                            || "initialize".equals(getMethodName()) || getMethod().isPrivate())) {
+                            || "init".equals(getMethodName()) || "initialize".equals(getMethodName())
+                            || getMethod().isPrivate())) {
 
                 if (isConstructor) {
                     data.writtenInConstructorFields.add(f);


### PR DESCRIPTION
Two subexpressions are equal here: `"init".equals(getMethodName())`. Maybe one was meant to be `"clinit".equals(getMethodName())`?