### PR TITLE
A proposal for OpcodeStack.Item#defineNewSpecialKind()

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -31,6 +31,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -269,15 +272,14 @@ public class OpcodeStack implements Constants2 {
         int TYPE_ONLY = 24;
 
         @edu.umd.cs.findbugs.internalAnnotations.StaticConstant
-        public static final HashMap<Integer, String> specialKindNames = new HashMap<Integer, String>();
+        public static final ConcurrentMap<Integer, String> specialKindNames = new ConcurrentHashMap<Integer, String>();
 
-        private static @SpecialKind int nextSpecialKind = asSpecialKind(TYPE_ONLY + 1);
+        private static AtomicInteger nextSpecialKind = new AtomicInteger(TYPE_ONLY + 1);
 
         public static @SpecialKind
         int defineNewSpecialKind(String name) {
-            specialKindNames.put(nextSpecialKind, name);
-            @SpecialKind int result = nextSpecialKind;
-            nextSpecialKind = asSpecialKind(nextSpecialKind + 1);
+            @SpecialKind int result = asSpecialKind(nextSpecialKind.getAndIncrement());
+            specialKindNames.put(Integer.valueOf(result), name);
             return result;
         }
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -186,6 +186,9 @@ public class OpcodeStack implements Constants2 {
 
     public static class Item {
 
+        /**
+         * A type qualifier to mark {@code int} value as SpecialKind type.
+         */
         @Documented
         @TypeQualifier(applicableTo = Integer.class)
         @Retention(RetentionPolicy.RUNTIME)
@@ -276,6 +279,13 @@ public class OpcodeStack implements Constants2 {
 
         private static AtomicInteger nextSpecialKind = new AtomicInteger(TYPE_ONLY + 1);
 
+        /**
+         * Define new SpecialKind with given name, and return its {@code int} value
+         * @param name
+         *      the name of new SpecialKind, can be null
+         * @return
+         *      {@code int} value which expresses new SpecialKind
+         */
         public static @SpecialKind
         int defineNewSpecialKind(String name) {
             @SpecialKind int result = asSpecialKind(nextSpecialKind.getAndIncrement());

--- a/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/OpcodeStack.java
@@ -276,8 +276,8 @@ public class OpcodeStack implements Constants2 {
         public static @SpecialKind
         int defineNewSpecialKind(String name) {
             specialKindNames.put(nextSpecialKind, name);
-            @SpecialKind int result = asSpecialKind( nextSpecialKind+1);
-            nextSpecialKind = result;
+            @SpecialKind int result = nextSpecialKind;
+            nextSpecialKind = asSpecialKind(nextSpecialKind + 1);
             return result;
         }
 

--- a/findbugs/src/junit/edu/umd/cs/findbugs/OpcodeStackItemTest.java
+++ b/findbugs/src/junit/edu/umd/cs/findbugs/OpcodeStackItemTest.java
@@ -41,4 +41,20 @@ public class OpcodeStackItemTest extends TestCase {
         assertEquals(0,m2.getConstant());
     }
 
+    private static final String NEW_ITEM_KIND_NAME = "newItemKindName";
+    public void testDefineNewItemKind() {
+        int defined = OpcodeStack.Item.defineNewSpecialKind(NEW_ITEM_KIND_NAME);
+        assertEquals(NEW_ITEM_KIND_NAME,
+                OpcodeStack.Item.specialKindNames.get(Integer.valueOf(defined)));
+    }
+
+    public void testDefinedItemKindIsUsedInToStringMethod() {
+        int defined = OpcodeStack.Item.defineNewSpecialKind(NEW_ITEM_KIND_NAME);
+        OpcodeStack.Item intItem = new OpcodeStack.Item("I");
+        intItem.setSpecialKind(defined);
+        String result = intItem.toString();
+        assertTrue("Item.toString() does not use proper name of special kind:" + result,
+                result.contains(NEW_ITEM_KIND_NAME));
+    }
+
 }


### PR DESCRIPTION
It seems that current implementation has two problems:
1. `defineNewSpecialKind(String)` method returns an `int` value which is not same with actual newly defined SpecialKind
2. `specialKindNames` field is not thread-safe, even though it is annotated with `@StaticConstant` so it will be shared between analysis runs.

Are they intended behaviour? Here I will propose JUnit tests to explain the first problem, and new implementation to solve both of two problems. Could you check it, please?  
Note that this PR changes type of `specialKindNames` public field. If we should keep it, we can use `synchronised` block instead of `ConcurrentMap`.
