### PR TITLE
Undeprecate findbugs annotations as using jsr305 is brain dead.

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/CheckForNull.java
@@ -24,9 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
-
 /**
  * The annotated element might be null, and uses of the element should check for
  * null.
@@ -34,14 +31,10 @@ import javax.annotation.meta.When;
  * When this annotation is applied to a method it applies to the method return
  * value.
  *
- * @deprecated - use {@link javax.annotation.CheckForNull} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
-@javax.annotation.Nonnull(when = When.MAYBE)
-@TypeQualifierNickname
-@Deprecated
 public @interface CheckForNull {
 
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/CheckReturnValue.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/CheckReturnValue.java
@@ -30,12 +30,10 @@ import java.lang.annotation.Target;
  *
  * The checker treats this annotation as inherited by overriding methods.
  *
- * @deprecated - use {@link javax.annotation.CheckReturnValue} instead.
  */
 @Documented
 @Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface CheckReturnValue {
 
     @Deprecated

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/Confidence.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/Confidence.java
@@ -19,8 +19,6 @@
 
 package edu.umd.cs.findbugs.annotations;
 
-import javax.annotation.Nonnull;
-
 /**
  * Describes the confidence with which FindBugs reports a bug instance.
  */
@@ -33,7 +31,7 @@ public enum Confidence {
     private final int confidenceValue;
 
     /** Given a numeric confidence value, report the corresponding confidence enum value */
-    @Nonnull
+    @NonNull
     static public Confidence getConfidence(int prio) {
         for(Confidence c : values()) {
             if (prio <= c.confidenceValue) {

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotation.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotation.java
@@ -26,9 +26,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.Nonnegative;
-import javax.annotation.meta.TypeQualifierDefault;
-
 
 /**
  * Indicates that all members of the class or package should be annotated with
@@ -41,28 +38,12 @@ import javax.annotation.meta.TypeQualifierDefault;
  * package, and then use @Nullable only on those parameters, methods or fields
  * that you want to allow to be null.
  *
- * @deprecated -  Use the JSR305 annotations instead.
- * For example, you can use {@link javax.annotation.ParametersAreNonnullByDefault} instead
- * of @DefaultAnnotation(NonNull.class) so that method parameters are nonnull by default in the annotated
- * element. You can also use {@link javax.annotation.meta.TypeQualifierDefault}
- * in general to define your own annotation that specifies a default type qualifier. For example,
- * <p><pre><code>
- * {@link Nonnegative}
- * {@link TypeQualifierDefault}({@link ElementType#PARAMETER})
- * public @interface ParametersAreNonnegativeByDefault {}
- * </code></pre>
- *
- * <p>The JSR305 {@link javax.annotation.CheckReturnValue}
- * annotation can be applied to a type or package, and it will act as a default for all methods
- * in that class or package unless otherwise overridden.
- *
  * @author William Pugh
  */
 
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotation {
     Class<? extends Annotation>[] value();
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForFields.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForFields.java
@@ -43,7 +43,6 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForFields {
     Class<? extends Annotation>[] value();
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForMethods.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForMethods.java
@@ -43,7 +43,6 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForMethods {
     Class<? extends Annotation>[] value();
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForParameters.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/DefaultAnnotationForParameters.java
@@ -37,20 +37,12 @@ import java.lang.annotation.Target;
  * package, and then use @Nullable only on those parameters, methods or fields
  * that you want to allow to be null.
  *
- * @deprecated -  use the JSR305 annotations instead,
- * For example, you can use {@link javax.annotation.ParametersAreNonnullByDefault} instead
- * of @DefaultAnnotation(NonNull.class), and {@link javax.annotation.meta.TypeQualifierDefault}
- * in general to define a type qualifier default. The JSR305 {@link javax.annotation.CheckReturnValue}
- * annotation can be applied to a type or package, and it will act as a default for all methods
- * in that class or package unless otherwise overridden.
- *
  * @author William Pugh
  */
 
 @Documented
 @Target({ ElementType.TYPE, ElementType.PACKAGE })
 @Retention(RetentionPolicy.CLASS)
-@Deprecated
 public @interface DefaultAnnotationForParameters {
     Class<? extends Annotation>[] value();
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/NonNull.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/NonNull.java
@@ -24,23 +24,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
-
 /**
  * The annotated element must not be null.
  *
  * Annotated Fields must only not be null after construction has completed.
  * Annotated methods must have non-null return values.
  *
- * @deprecated - use {@link javax.annotation.Nonnull} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
-@javax.annotation.Nonnull(when = When.ALWAYS)
-@TypeQualifierNickname
-@Deprecated
 public @interface NonNull {
 
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/Nullable.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/Nullable.java
@@ -24,9 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
-
 /**
  * The annotated element could be null under some circumstances.
  *
@@ -37,14 +34,10 @@ import javax.annotation.meta.When;
  * When this annotation is applied to a method it applies to the method return
  * value.
  *
- * @deprecated - use {@link javax.annotation.Nullable} instead.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
-@javax.annotation.Nonnull(when = When.UNKNOWN)
-@TypeQualifierNickname
-@Deprecated
 public @interface Nullable {
 
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/OverrideMustInvoke.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/OverrideMustInvoke.java
@@ -34,12 +34,8 @@ import java.lang.annotation.Target;
  * at any time, at the beginning of the overriding method, or at the end of the
  * overriding method.
  *
- * @see edu.umd.cs.findbugs.annotations.When
- *
- * @deprecated - Use {@link javax.annotation.OverridingMethodsMustInvokeSuper} instead
  **/
 @Documented
-@Deprecated
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.CLASS)
 public @interface OverrideMustInvoke {

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/PossiblyNull.java
@@ -24,9 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
-
 /**
  * The annotated element should might be null, and uses of the element should
  * check for null.
@@ -34,16 +31,10 @@ import javax.annotation.meta.When;
  * When this annotation is applied to a method it applies to the method return
  * value.
  *
- * @deprecated - use CheckForNull instead; the name of which more clearly
- *             indicates that not only could the value be null, but that good
- *             coding practice requires that the value be checked for null.
  **/
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
-@javax.annotation.Nonnull(when = When.MAYBE)
-@TypeQualifierNickname
-@Deprecated
 public @interface PossiblyNull {
 
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/ReturnValuesAreNonnullByDefault.java
@@ -20,12 +20,8 @@
 package edu.umd.cs.findbugs.annotations;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierDefault;
 
 /**
  * This annotation can be applied to a package, class or method to indicate that
@@ -40,9 +36,6 @@ import javax.annotation.meta.TypeQualifierDefault;
  *
  */
 @Documented
-@Nonnull
-@TypeQualifierDefault(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@Deprecated
 public @interface ReturnValuesAreNonnullByDefault {
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/UnknownNullness.java
@@ -24,9 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.annotation.meta.TypeQualifierNickname;
-import javax.annotation.meta.When;
-
 /**
  * Used to indicate that the nullness of element is unknown, or may vary in
  * unknown ways in subclasses.
@@ -34,9 +31,6 @@ import javax.annotation.meta.When;
 @Documented
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 @Retention(RetentionPolicy.CLASS)
-@javax.annotation.Nonnull(when = When.UNKNOWN)
-@TypeQualifierNickname
-@Deprecated
 public @interface UnknownNullness {
 
 }

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/When.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/When.java
@@ -22,7 +22,6 @@ package edu.umd.cs.findbugs.annotations;
 /**
  * @author pugh
  */
-@Deprecated
 public enum When {
     FIRST, ANYTIME, LAST
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/annotations/package-info.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/annotations/package-info.java
@@ -1,25 +1,6 @@
 /**
- * Annotations for FindBugs (mostly deprecated except for {@link edu.umd.cs.findbugs.annotations.SuppressFBWarnings}).
+ * Annotations for FindBugs.
  *
- * This annotations are mostly deprecated and replaced by JSR 305 annotations
- * defined in javax.annotation. The annotations still actively supported are:
- * <ul>
- * <li> {@link edu.umd.cs.findbugs.annotations.SuppressFBWarnings} for suppressing FindBugs warnings
- * <li> Annotations about expected/unexpected warnings in FindBugs regression tests
- * <ul>
- * <li>  {@link edu.umd.cs.findbugs.annotations.ExpectWarning} Warnings expected to be generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.NoWarning} Warnings that should not  be generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.DesireWarning} Warnings we wish to generated
- *  <li>  {@link edu.umd.cs.findbugs.annotations.DesireNoWarning} Warnings we wish to not generate generated
- *  </ul></ul>
- *
- *  There are another set of annotations used by an experimental detector for unclosed resources:
- *  <ul>
- *  <li>{@link edu.umd.cs.findbugs.annotations.CleanupObligation}
- *  <li>{@link edu.umd.cs.findbugs.annotations.CreatesObligation}
- *  <li>{@link edu.umd.cs.findbugs.annotations.DischargesObligation}
- *  </ul>
-
  */
 package edu.umd.cs.findbugs.annotations;
 

--- a/pom/annotations/pom.xml
+++ b/pom/annotations/pom.xml
@@ -40,12 +40,6 @@
       <version>1.0</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.1</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <developers>
@@ -96,7 +90,7 @@
            <goal>jar</goal>
           </goals>
           <configuration>
-           <subpackages>edu.umd.cs.findbugs.annotations:net.jcip.annotations:javax.annotation:javax.annotation.meta:javax.annotation.concurrent</subpackages>
+           <subpackages>edu.umd.cs.findbugs.annotations:net.jcip.annotations</subpackages>
            <includeDependencySources>true</includeDependencySources>
            <quiet>true</quiet>
           </configuration>
@@ -154,7 +148,7 @@
          <Bundle-Name>${project.name}</Bundle-Name>
          <Bundle-RequiredExecutionEnvironment>J2SE-1.5</Bundle-RequiredExecutionEnvironment>
          <Import-Package></Import-Package>
-         <Export-Package>edu.umd.cs.findbugs.annotations;javax.annotation;javax.annotation.concurrent;javax.annotation.meta;net.jcip.annotations</Export-Package>
+         <Export-Package>edu.umd.cs.findbugs.annotations;net.jcip.annotations</Export-Package>
         </instructions>
        </configuration>
       </plugin>

--- a/pom/findbugs-annotations/pom.xml
+++ b/pom/findbugs-annotations/pom.xml
@@ -33,16 +33,6 @@
     <url>https://github.com/findbugsproject/findbugs/</url>
   </scm>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.1</version>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-  </dependencies>
-
   <developers>
     <developer>
       <id>bp</id>


### PR DESCRIPTION
The default Annotation bits are likely broken as they seem to rely on jsr
meta annotations to do their job.
### There is NO SUCH THING AS JSR-305.
- The spec is non existent - not even a draft.
- There is only a snapshot of some code in a repository at some moment in
  time - with dubios licensing (contains CC by 2.5 code)
- Should that JSR even become non dormant the annotations could change in a non backwards compatible way
- What there is uses the `javax` namespace which is reserved for official
  specification.  As there is no specification this can not be official
- Shipping code in `javax` namespace with an application and an Oracle JDK is in direct
  violation of the oracle licence agreement - and is likely in violation of trademark terms for non Oracle JDKs for non official specs.

This is considered your starter for 10 and a clue stick.

See #88 
