### PR TITLE
Supports android.support.annotation.Nullable/NonNull

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/NullnessAnnotation.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/NullnessAnnotation.java
@@ -44,6 +44,7 @@ public class NullnessAnnotation extends AnnotationEnumeration<NullnessAnnotation
             className = ClassName.toDottedClassName(className);
             if ("com.google.common.base.Nullable".equals(className)
                     || "org.eclipse.jdt.annotation.Nullable".equals(className)
+                    || "android.support.annotation.Nullable".equals(className)
                     || "org.jetbrains.annotations.Nullable".equals(className)) {
                 return CHECK_FOR_NULL;
             }

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/jsr305/TypeQualifierResolver.java
@@ -64,6 +64,10 @@ public class TypeQualifierResolver {
     // javax.annotations.ParametersAreNonnullByDefault ?
     static final ClassDescriptor eclipseNonNullByDefault = DescriptorFactory.createClassDescriptor("org/eclipse/jdt/annotation/NonNullByDefault");
 
+    static final ClassDescriptor androidNullable = DescriptorFactory.createClassDescriptor("android/support/annotation/Nullable");
+
+    static final ClassDescriptor androidNonNull = DescriptorFactory.createClassDescriptor("android/support/annotation/NonNull");
+
     /**
      * Resolve an AnnotationValue into a list of AnnotationValues representing
      * type qualifier annotations.
@@ -126,11 +130,14 @@ public class TypeQualifierResolver {
             try {
                 if (annotationClass.equals(googleNullable)
                         || annotationClass.equals(eclipseNullable)
+                        || annotationClass.equals(androidNullable)
                         || annotationClass.equals(intellijNullable)) {
                     resolveTypeQualifierNicknames(new AnnotationValue(JSR305NullnessAnnotations.CHECK_FOR_NULL), result, onStack);
                     return;
                 }
-                if (annotationClass.equals(eclipseNonNull) || annotationClass.equals(eclipseNonNullByDefault)
+                if (annotationClass.equals(eclipseNonNull)
+                        || annotationClass.equals(eclipseNonNullByDefault)
+                        || annotationClass.equals(androidNonNull)
                         || annotationClass.equals(intellijNotNull)) {
                     resolveTypeQualifierNicknames(new AnnotationValue(JSR305NullnessAnnotations.NONNULL), result, onStack);
                     return;


### PR DESCRIPTION
Hi, this introduces support for FindBugs to recognize
android.support.annotation.Nullable as CHECK_FOR_NULL and
android.support.annotation.NonNull as NONNULL.
While it is annoying that there are so many nullability annotations out in the wild and these are just another set of them, these are the only nullability annotations supported by Android Studio, so even if you develop on another IDE, but share code with Android Studio developers, these are the only way to go.
Hopefully soon there will be a Java standard for null annotations ...
