### PR TITLE
Allow processing a dynamically calculated set of class folders.

### DIFF
--- a/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
+++ b/findbugs/src/antTask/edu/umd/cs/findbugs/anttask/FindBugsTask.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.types.DirSet;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
@@ -169,6 +170,8 @@ public class FindBugsTask extends AbstractFindBugsTask {
     private boolean setExitCode = true;
 
     private final List<FileSet> filesets = new ArrayList<FileSet>();
+
+    private final List<DirSet> dirsets = new ArrayList<DirSet>();
 
     public FindBugsTask() {
         super("edu.umd.cs.findbugs.FindBugs2");
@@ -567,13 +570,20 @@ public class FindBugsTask extends AbstractFindBugsTask {
     }
 
     /**
+     * Add a nested dirset of classes dirs.
+     */
+    public void addDirset(DirSet fs) {
+        dirsets.add(fs);
+    }
+
+    /**
      * Check that all required attributes have been set
      */
     @Override
     protected void checkParameters() {
         super.checkParameters();
 
-        if (projectFile == null && classLocations.size() == 0 && filesets.size() == 0 && auxAnalyzepath == null) {
+        if (projectFile == null && classLocations.size() == 0 && filesets.size() == 0 && dirsets.size() == 0 && auxAnalyzepath == null) {
             throw new BuildException("either projectfile, <class/>, <fileset/> or <auxAnalyzepath/> child "
                     + "elements must be defined for task <" + getTaskName() + "/>", getLocation());
         }
@@ -801,6 +811,14 @@ public class FindBugsTask extends AbstractFindBugsTask {
         for (FileSet fs : filesets) {
             DirectoryScanner ds = fs.getDirectoryScanner();
             for (String fileName : ds.getIncludedFiles()) {
+                File file = new File(ds.getBasedir(), fileName);
+                addArg(file.toString());
+            }
+        }
+
+        for (DirSet fs : dirsets) {
+            DirectoryScanner ds = fs.getDirectoryScanner();
+            for (String fileName : ds.getIncludedDirectories()) {
                 File file = new File(ds.getBasedir(), fileName);
                 addArg(file.toString());
             }

--- a/findbugs/src/doc/manual.xml
+++ b/findbugs/src/doc/manual.xml
@@ -1275,10 +1275,12 @@ using the &FindBugs; task.
        elements may be specified as children of a single <literal>findbugs</literal> element.
        </para>
        <para>In addition to or instead of specifying a <literal>class</literal> element,
-       the  &FindBugs; task can contain one or more <literal>fileset</literal> element(s) that
-       specify files to be analyzed.
+       the  &FindBugs; task can contain one or more <literal>fileset</literal> or <literal>dirset</literal> element(s) that
+       specify files or class folders to be analyzed.
        For example, you might use a fileset to specify that all of the jar files in a directory
        should be analyzed.
+       Using a dirset, you can have ANT dynamically collect the class folders of multiple sub-projects to be 
+       analyzed in a single run.
        </para>
     </listitem>
   </varlistentry>


### PR DESCRIPTION
The ANT task currently can invoke FindBugs on the contents of multiple
class folders only if the folders are explicitly given using multiple
`<class location="..."/>` elements. If the names of the class folders are
not statically known, it is currently not possible to let ANT collect a
set of directories and pass this to the FindBugs task. To support this
use case, a nested `<dirset>` element is added to the task that behaves
like a nested `<fileset>` element for explicitly referencing multiple
class files.