### PR TITLE
Tests should run from Eclipse and Maven

### DIFF
--- a/findbugs/src/junit/edu/umd/cs/findbugs/architecture/PackageDependenciesTest.java
+++ b/findbugs/src/junit/edu/umd/cs/findbugs/architecture/PackageDependenciesTest.java
@@ -58,12 +58,24 @@ public class PackageDependenciesTest extends TestCase {
     protected void setUp() throws Exception {
         super.setUp();
 
+        engine = new JDepend();
+
         // Get the classes root directory
-        String rootDirectory = new File(getClass().getResource("/").toURI()).getCanonicalPath();
+        String classpath = System.getProperty("java.class.path");
+        if (classpath == null) {
+            String rootDirectory = new File(getClass().getResource("/").toURI()).getCanonicalPath();
+            engine.addDirectory(rootDirectory);
+        } else {
+        	String[] cpParts = classpath.split(File.pathSeparator);
+        	for (String cpStr : cpParts) {
+        		File file = new File(cpStr);
+				if (file.isDirectory()) {
+        			engine.addDirectory(file.getCanonicalPath());
+        		}
+        	}
+        }
 
         // Setup the JDepend analysis
-        engine = new JDepend();
-        engine.addDirectory(rootDirectory);
         engine.analyze();
     }
 


### PR DESCRIPTION
Running `PackageDependenciesTest` from either eclipse or Maven will fail.

On both cases, tests are located at `{basedir}/target/test-classes/` and core classes at `{basedir}/target/classes/`, and both directories are part of the classpath, but `getClass().getResource("/")` will always point to `{basedir}/target/test-classes/` since it's the first entry on the classpath, meaning all core classes (which are those we test!) are never found.

This changeset makes sure all directories in the classpath are taken into account when performing JDepend analysis, allowing both Eclipse and Maven to succceed when running it.