### PR TITLE
Don't canonicalize strings

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/classfile/DescriptorFactory.java
@@ -33,6 +33,7 @@ import org.apache.bcel.generic.ObjectType;
 
 import edu.umd.cs.findbugs.FieldAnnotation;
 import edu.umd.cs.findbugs.MethodAnnotation;
+import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.classfile.analysis.MethodInfo;
 import edu.umd.cs.findbugs.internalAnnotations.DottedClassName;
 import edu.umd.cs.findbugs.internalAnnotations.SlashedClassName;
@@ -46,6 +47,8 @@ import edu.umd.cs.findbugs.util.MapCache;
  * @author David Hovemeyer
  */
 public class DescriptorFactory {
+    private static final boolean USE_STRING_INTERNING = SystemProperties.getBoolean("findbugs.useStringsInterning");
+
     private static ThreadLocal<DescriptorFactory> instanceThreadLocal = new ThreadLocal<DescriptorFactory>() {
         @Override
         protected DescriptorFactory initialValue() {
@@ -71,6 +74,10 @@ public class DescriptorFactory {
     private final MapCache<String, String> stringCache = new MapCache<String, String>(10000);
 
     public static String canonicalizeString(@CheckForNull String s) {
+        if (!USE_STRING_INTERNING) {
+            return s;
+        }
+
         if (s == null) {
             return s;
         }


### PR DESCRIPTION
Right now, canonicalization provides no consistent benefits, and actually do cause harm.

Since canonicalization is performed over a LRU cache, there is no guarantee strings are actually canonical (an old entry may still be used, but discarded from the cache due to LRU). Therefore, we can't speed up any string comparison by using `==` instead of equals (the code is correct, and never assumes canonical strings to actually be canonical in this respect). On the contrary, the process of canonicalization actually takes CPU cycles. Even if it's fast, it's called so many times, that it ends up adding a couple **seconds** to every run.

It also doesn't guarantee to help memory usage. Since the cache holds strong references to Strings, any entry that is no longer used is still hold in memory due to the cache, and never discarded by the GC.

For reference, here are some benchmarks obtained by runnning:

```
for i in 1 2 3 4 5; do time java -classpath : -Dfindbugs.home=~/findbugs-3.0.1 -Xmx768m -Dfindbugs.launchUI=0 -jar ~/findbugs-3.0.1/lib/findbugs.jar -project ~/findbugs-3.0.1/dummy.xml &> /dev/null; done
```
### Original

```
real    0m16.734s
user    0m53.080s
sys     0m0.488s

real    0m13.701s
user    0m44.564s
sys     0m0.340s

real    0m13.777s
user    0m44.504s
sys     0m0.396s

real    0m13.107s
user    0m43.896s
sys     0m0.312s

real    0m13.302s
user    0m44.360s
sys     0m0.340s
```
### This changeset

```
real    0m12.384s
user    0m40.580s
sys     0m0.380s

real    0m12.879s
user    0m42.568s
sys     0m0.412s

real    0m12.865s
user    0m43.136s
sys     0m0.280s

real    0m12.760s
user    0m42.560s
sys     0m0.272s

real    0m13.439s
user    0m44.660s
sys     0m0.332s
```
