### PR TITLE
Added bug pattern "OVERRIDING_METHODS_MUST_INVOKE_SUPER"

### DIFF
--- a/findbugs/etc/findbugs.xml
+++ b/findbugs/etc/findbugs.xml
@@ -289,6 +289,9 @@
                               <Later class="edu.umd.cs.findbugs.detect.CheckExpectedWarnings"/>
                     </SplitPass>
           </OrderingConstraints>
+
+          <Detector class="edu.umd.cs.findbugs.detect.CbeckMustOverrideSuperAnnotation"
+                    reports="OVERRIDING_METHODS_MUST_INVOKE_SUPER" speed="fast" hidden="false"/>
           <Detector class="edu.umd.cs.findbugs.detect.FindRoughConstants"
                     reports="CNT_ROUGH_CONSTANT_VALUE" speed="fast" hidden="false"/>
 
@@ -672,6 +675,7 @@
           <BugCode abbrev="FB"/>
           <BugCode abbrev="AT"/>
           <!-- Bug patterns -->
+          <BugPattern abbrev="CN" type="OVERRIDING_METHODS_MUST_INVOKE_SUPER" category="CORRECTNESS" />
           <BugPattern abbrev="CNT" type="CNT_ROUGH_CONSTANT_VALUE" category="BAD_PRACTICE"/>
 
           <BugPattern abbrev="AT" type="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION"

--- a/findbugs/etc/messages.xml
+++ b/findbugs/etc/messages.xml
@@ -165,6 +165,14 @@ This plugin contains all of the standard FindBugs detectors.
   Detectors
   **********************************************************************
    -->
+  <Detector class="edu.umd.cs.findbugs.detect.CbeckMustOverrideSuperAnnotation">
+    <Details>
+<![CDATA[
+<p> Finds methods that must call super.
+</p>
+]]>
+    </Details>
+  </Detector>
   <Detector class="edu.umd.cs.findbugs.detect.FindRoughConstants">
     <Details>
 <![CDATA[
@@ -1656,6 +1664,14 @@ factory pattern to create these objects.</p>
   BugPatterns
   **********************************************************************
    -->
+  <BugPattern type="OVERRIDING_METHODS_MUST_INVOKE_SUPER">
+    <ShortDescription>Super method is annotated with @OverridingMethodsMustInvokeSuper, but the overriding method isn't calling the super method.</ShortDescription>
+    <LongDescription>Super method is annotated with @OverridingMethodsMustInvokeSuper, but {1} isn't calling the super method.</LongDescription>
+    <Details>
+      <![CDATA[
+    <p>Super method is annotated with @OverridingMethodsMustInvokeSuper, but the overriding method isn't calling the super method.</p>
+]]>
+    </Details>  </BugPattern>
   <BugPattern type="CNT_ROUGH_CONSTANT_VALUE">
     <ShortDescription>Rough value of known constant found</ShortDescription>
     <LongDescription>Rough value of {3} found: {2}</LongDescription>

--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/CbeckMustOverrideSuperAnnotation.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/CbeckMustOverrideSuperAnnotation.java
@@ -26,7 +26,6 @@ import org.apache.bcel.classfile.Code;
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Lookup;
-import edu.umd.cs.findbugs.SystemProperties;
 import edu.umd.cs.findbugs.ba.XMethod;
 import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import edu.umd.cs.findbugs.classfile.ClassDescriptor;
@@ -35,29 +34,23 @@ import edu.umd.cs.findbugs.classfile.analysis.AnnotationValue;
 
 public class CbeckMustOverrideSuperAnnotation extends OpcodeStackDetector {
 
-    BugReporter bugReporter;
+    private final BugReporter bugReporter;
 
     ClassDescriptor mustOverrideAnnotation = DescriptorFactory.createClassDescriptor(OverridingMethodsMustInvokeSuper.class);
 
-    private final boolean testingEnabled;
-
     public CbeckMustOverrideSuperAnnotation(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
-        testingEnabled = SystemProperties.getBoolean("report_TESTING_pattern_in_standard_detectors");
     }
 
     private boolean sawCallToSuper;
 
     @Override
     public void visit(Code code) {
-        if(!testingEnabled){
+        if (getMethod().isStatic() || getMethod().isPrivate() || getMethod().isSynthetic()) {
             return;
         }
-        if (getMethod().isStatic() || getMethod().isPrivate()) {
-            return;
-        }
-        XMethod overrides = Lookup.findSuperImplementorAsXMethod(getThisClass(), getMethodName(), getMethodSig(), bugReporter);
 
+        XMethod overrides = Lookup.findSuperImplementorAsXMethod(getThisClass(), getMethodName(), getEffectiveMethodSig(), bugReporter);
         if (overrides == null) {
             return;
         }
@@ -68,9 +61,20 @@ public class CbeckMustOverrideSuperAnnotation extends OpcodeStackDetector {
         sawCallToSuper = false;
         super.visit(code);
         if (!sawCallToSuper) {
-            bugReporter.reportBug(new BugInstance(this, "TESTING", NORMAL_PRIORITY).addClassAndMethod(this).addString(
+            bugReporter.reportBug(new BugInstance(this, "OVERRIDING_METHODS_MUST_INVOKE_SUPER", NORMAL_PRIORITY).addClassAndMethod(this).addString(
                     "Method must invoke override method in superclass"));
         }
+    }
+
+    public String getEffectiveMethodSig() {
+        String methodSig = getMethodSig();
+        XMethod bridgeFrom = getXMethod().bridgeFrom();
+
+        if (bridgeFrom != null) {
+            methodSig = bridgeFrom.getSignature();
+        }
+
+        return methodSig;
     }
 
     /*
@@ -88,7 +92,7 @@ public class CbeckMustOverrideSuperAnnotation extends OpcodeStackDetector {
         String calledMethodName = getNameConstantOperand();
         String calledMethodSig = getSigConstantOperand();
         if (calledClassName.equals(getSuperclassName()) && calledMethodName.equals(getMethodName())
-                && calledMethodSig.equals(getMethodSig())) {
+                && calledMethodSig.equals(getEffectiveMethodSig())) {
             sawCallToSuper = true;
         }
 

--- a/findbugsTestCases/src/java/CbeckMustOverrideSuperAnnotationTest.java
+++ b/findbugsTestCases/src/java/CbeckMustOverrideSuperAnnotationTest.java
@@ -1,0 +1,22 @@
+import javax.annotation.OverridingMethodsMustInvokeSuper;
+
+import edu.umd.cs.findbugs.annotations.ExpectWarning;
+
+public class CbeckMustOverrideSuperAnnotationTest {
+    public static class GenericClass<T > {
+        @OverridingMethodsMustInvokeSuper
+        public void genericMethod( T obj ) {
+        }
+    }
+
+    public class ConcreteClass extends GenericClass<String > {
+    }
+
+    public class CLtbe_AgentCallback extends ConcreteClass {
+        @ExpectWarning( "OVERRIDING_METHODS_MUST_INVOKE_SUPER" )
+        @Override
+        public void genericMethod( String obj ) {
+            // no call to super.genericMethod( obj )
+        }
+    }
+}


### PR DESCRIPTION
I have added the bug pattern "OVERRIDING_METHODS_MUST_INVOKE_SUPER" for the improved detector "CbeckMustOverrideSuperAnnotation".
Now the detector is able to follow an invokevirtual instruction used for templated method calls.
