### PR TITLE
Issue a bug for BigDecimal(double) when the argument is not a constant

### DIFF
--- a/findbugs/src/java/edu/umd/cs/findbugs/detect/DumbMethods.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/detect/DumbMethods.java
@@ -1405,6 +1405,12 @@ public class DumbMethods extends OpcodeStackDetector {
                                 .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(dblString)
                                 .addString(bigDecimalString).addSourceLine(this));
                     }
+                } else {
+                    bugReporter.reportBug(new BugInstance(this, "DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE",
+                            NORMAL_PRIORITY).addClassAndMethod(this).addCalledMethod(this)
+                            .addMethod("java.math.BigDecimal", "valueOf", "(D)Ljava/math/BigDecimal;", true)
+                            .describe(MethodAnnotation.METHOD_ALTERNATIVE_TARGET).addString(top.getSignature())
+                            .addSourceLine(this));
                 }
 
             }

--- a/findbugsTestCases/src/java/sfBugs/RFE2891944.java
+++ b/findbugsTestCases/src/java/sfBugs/RFE2891944.java
@@ -25,7 +25,17 @@ public class RFE2891944 {
         BigDecimal bd = new BigDecimal(1.0);
         System.out.println(bd);
     }
-    
+
+    @ExpectWarning(value="DMI_BIGDECIMAL_CONSTRUCTED_FROM_DOUBLE", confidence=Confidence.MEDIUM)
+    public static void bug4() {
+        BigDecimal bd = new BigDecimal(getDoubleValue());
+        System.out.println(bd);
+    }
+
+    private static double getDoubleValue() {
+        return 2.5d;
+    }
+
     public static void main(String args[]) {
         bug1();
         bug2();


### PR DESCRIPTION
The BigDecimal(double) detector only reported an issue when the argument
to the constructor was a constant whose value would cause rounding errors.

Now it also reports an issue if the value is *not* a constant.