### PR TITLE
Detect the object-level redundancy issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Project development continues here: https://github.com/spotbugs/spotbugs
 
-Please read this for details: 
+P1lease read this for details: 
 
 - https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2016-November/004321.html
 - https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2017-September/004383.html

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Project development continues here: https://github.com/spotbugs/spotbugs
 
-P1lease read this for details: 
+Please read this for details: 
 
 - https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2016-November/004321.html
 - https://mailman.cs.umd.edu/pipermail/findbugs-discuss/2017-September/004383.html

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/BasicAbstractDataflowAnalysis.java
@@ -42,6 +42,12 @@ public abstract class BasicAbstractDataflowAnalysis<Fact> implements DataflowAna
 
     private final IdentityHashMap<BasicBlock, Fact> resultFactMap;
 
+    public BasicBlock tmp_startblock;
+    public Fact tmp_startfact;
+    public BasicBlock tmp_resultblock;
+    public Fact tmp_resultfact;
+    public int flag;
+
     /**
      * Constructor.
      */
@@ -67,12 +73,24 @@ public abstract class BasicAbstractDataflowAnalysis<Fact> implements DataflowAna
 
     @Override
     public/* final */Fact getStartFact(BasicBlock block) {
-        return lookupOrCreateFact(startFactMap, block);
+        if(!(tmp_startblock.equals(block))) {
+            tmp_startblock = block;
+            flag = 0;
+            return lookupOrCreateFact(startFactMap, block, flag);
+        }
+        else
+            return tmp_startfact;
     }
 
     @Override
     public/* final */Fact getResultFact(BasicBlock block) {
-        return lookupOrCreateFact(resultFactMap, block);
+        if(!(tmp_resultblock.equals(block))) {
+            tmp_resultblock = block;
+            flag = 1;
+            return lookupOrCreateFact(resultFactMap, block, flag);
+        }
+        else
+            return tmp_resultfact;
     }
 
     /**
@@ -179,12 +197,16 @@ public abstract class BasicAbstractDataflowAnalysis<Fact> implements DataflowAna
         // Subclasses may override.
     }
 
-    private Fact lookupOrCreateFact(Map<BasicBlock, Fact> map, BasicBlock block) {
+    private Fact lookupOrCreateFact(Map<BasicBlock, Fact> map, BasicBlock block, int flag) {
         Fact fact = map.get(block);
         if (fact == null) {
             fact = createFact();
             map.put(block, fact);
         }
+        if(flag == 0)
+            tmp_startfact = fact;
+        else
+            tmp_resultfact = fact;
         return fact;
     }
 

--- a/findbugs/src/java/edu/umd/cs/findbugs/ba/BasicBlock.java
+++ b/findbugs/src/java/edu/umd/cs/findbugs/ba/BasicBlock.java
@@ -120,6 +120,33 @@ public class BasicBlock extends AbstractVertex<Edge, BasicBlock> implements Debu
         this.numNonExceptionSuccessors = -1;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if(!(o instanceof BasicBlock)) {
+            return false;
+        }
+        BasicBlock other = (BasicBlock) o;
+        return this.firstInstruction == other.firstInstruction && 
+            this.lastInstruction == other.lastInstruction &&
+            this.exceptionThrower == other.exceptionThrower &&
+            this.exceptionGen == other.exceptionGen &&
+            this.inJSRSubroutine == other.inJSRSubroutine &&
+            this.numNonExceptionSuccessors == other.numNonExceptionSuccessors &&
+            this.hashCode() == other.hashCode();
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+
+        hashCode = hashCode * 37 + this.firstInstruction.hashCode();
+        hashCode = hashCode * 37 + this.lastInstruction.hashCode();
+        hashCode = hashCode * 37 + this.exceptionThrower.hashCode();
+        hashCode = hashCode * 37 + this.exceptionGen.hashCode();
+
+        return hashCode;
+    }
+
     public boolean isInJSRSubroutine() {
         return inJSRSubroutine;
     }


### PR DESCRIPTION
Hello,

We ran findbugs with our tool and detected the object-level redundancy issues (object-level redundancies that happen across objects sharing the same calling context). Our tool reports an object, BasicBlock block, which is accessed at line 183 in method lookupOrCreateFact of class BasicAbstractDataflowAnalysis. The optimized code is in this pull request.