### PR TITLE
Fix outdated link in LICENSE-jsr305.txt

### DIFF
--- a/findbugs/licenses/LICENSE-jsr305.txt
+++ b/findbugs/licenses/LICENSE-jsr305.txt
@@ -1,7 +1,7 @@
 The JSR-305 reference implementation (lib/jsr305.jar) is
 distributed under the terms of the New BSD license:
 
-  http://www.opensource.org/licenses/bsd-license.php
+  https://opensource.org/license/bsd-3-clause
   
 See the JSR-305 home page for more information:
 


### PR DESCRIPTION
The old link does not exist anymore and now redirects to the BSD-2-Clause page. The correct license for JSR-305 is BSD-3-Clause. Following the old link requires extra clicks and causes confusion, so this change updates the link to point directly to BSD-3-Clause (aka "New BSD license") terms.